### PR TITLE
エネミーがひっかかる原因が全プッシュ時に再発生してたのでなおした

### DIFF
--- a/SlowGames/Assets/Resources/Prefabs/Test/EnemyTest/BeeEnemy/BeeEnemy_Double.prefab
+++ b/SlowGames/Assets/Resources/Prefabs/Test/EnemyTest/BeeEnemy/BeeEnemy_Double.prefab
@@ -191,7 +191,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1242068687375224}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.28199998, y: 30.509998, z: -6.68}
+  m_LocalPosition: {x: -0.038000047, y: 30.57, z: -6.68}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4501423400839578}
@@ -334,7 +334,7 @@ Rigidbody:
   m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 112
+  m_Constraints: 126
   m_CollisionDetection: 0
 --- !u!65 &65993500604133232
 BoxCollider:
@@ -489,7 +489,7 @@ MonoBehaviour:
     shotDelay: 1
     generateRate: 0
   _activeCounter: 0
-  _generatePostion: 5
+  _generatePostion: 3
   _attackDamege: 2
 --- !u!137 &137031403495594404
 SkinnedMeshRenderer:

--- a/SlowGames/Assets/Resources/Prefabs/Test/EnemyTest/BeeEnemy/BeeEnemy_Single_High.prefab
+++ b/SlowGames/Assets/Resources/Prefabs/Test/EnemyTest/BeeEnemy/BeeEnemy_Single_High.prefab
@@ -230,7 +230,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1601191394965124}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.08199996, y: 30.490002, z: -6.82}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4041587021103808}

--- a/SlowGames/Assets/Resources/Prefabs/Test/EnemyTest/BeeEnemy/enemyC_Tackle.prefab
+++ b/SlowGames/Assets/Resources/Prefabs/Test/EnemyTest/BeeEnemy/enemyC_Tackle.prefab
@@ -101,7 +101,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1532482501004534}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.038000047, y: 30.57, z: -6.68}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4875580712134376}
@@ -176,7 +176,7 @@ Rigidbody:
   m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 112
+  m_Constraints: 126
   m_CollisionDetection: 0
 --- !u!65 &65775965416722098
 BoxCollider:
@@ -274,7 +274,7 @@ MonoBehaviour:
     shotDelay: 1
     generateRate: 0
   _activeCounter: 0
-  _generatePostion: 3
+  _generatePostion: 4
   _attackDamege: 2
 --- !u!114 &114455878612764528
 MonoBehaviour:

--- a/SlowGames/Assets/Works/Takumi/EnemyManageTest/GenerateManager.cs
+++ b/SlowGames/Assets/Works/Takumi/EnemyManageTest/GenerateManager.cs
@@ -167,7 +167,7 @@ public class GenerateManager : MonoBehaviour
             _currentEnemysCount[(int)targetPosition] += 1;
             
             //生成
-            _enemyGenerator.GenerateEnemy(EnemyType.Easy, targetPosition);    
+            _enemyGenerator.GenerateEnemy(EnemyType.Normal, targetPosition);    
                          
     }
 


### PR DESCRIPTION
[バグの再現方法 ] <再現率100%>
PrefabのFreezePostionのチェックをはずしたまま同じ出現位置で連続生成する。
生成時衝突しあって、velocityが加算、目的地までたどり着けない。
生成場所がランダム、また目的地方向にはじけることで、あたかもうまくいってるように見えていた。

[リファ後]
FreezePositionのチェックを全てつけておくだけでよし。
自分のPCでは問題なし。明日朝実機で再テスト.

[原因]
RigidBodyの変更のみだとおそらく変更された扱いになっておらず、
プッシュできてなかったので、それが原因の可能性。